### PR TITLE
Ignore eval method redefined warning

### DIFF
--- a/lib/ruby_warning_filter.rb
+++ b/lib/ruby_warning_filter.rb
@@ -81,6 +81,6 @@ class RubyWarningFilter < DelegateClass(IO)
   end
 
   def eval_redefined?(line)
-    line =~ /\(eval\):\d+: warning: previous definition of .+ was here/
+    line =~ /\(eval\):\d+: (warning: previous definition of .+ was here|warning: method redefined; .+)/
   end
 end

--- a/test/ruby_warnings_filter_test.rb
+++ b/test/ruby_warnings_filter_test.rb
@@ -5,7 +5,7 @@ require "minitest/autorun"
 require "stringio"
 STDOUT.sync = true
 
-class RubyWarningsFilterTest < MiniTest::Test
+class RubyWarningsFilterTest < Minitest::Test
   def setup
     @gems_dir = File.expand_path("../gems", __FILE__)
     @gems_link_dir = File.expand_path("../gems-link", __FILE__)
@@ -62,19 +62,25 @@ class RubyWarningsFilterTest < MiniTest::Test
     @err.write "/path/to/ruby/2.2.0/gems/compass-core-1.0.3/lib/gradient_support.rb:319: warning: method redefined; discarding old to_moz\n"
     @err.write "(eval):2: warning: previous definition of to_moz was here\n"
 
+    @err.write "/path/to/ruby/2.2.0/gems/sitemap_generator-6.3.0/lib/sitemap_generator/templates.rb:10: warning: method redefined; discarding old sitemap_sample\n"
+    @err.write "(eval):1: warning: method redefined; discarding old sitemap_sample\n"
+
     # in app
     @err.write "/path/to/app.rb:123: warning: method redefined; discarding old foo\n"
     @err.write "(eval):2: warning: previous definition of foo was here\n"
+
+    @err.write "(eval):1: warning: method redefined; discarding old sitemap_sample\n"
 
     @err.write "something other\n"
 
     assert_equal \
       "/path/to/app.rb:123: warning: method redefined; discarding old foo\n"\
       "(eval):2: warning: previous definition of foo was here\n"\
+      "(eval):1: warning: method redefined; discarding old sitemap_sample\n"\
       "something other\n",
       @err.string
-    
-    assert_equal 2, @err.ruby_warnings
+
+    assert_equal 3, @err.ruby_warnings
   end
 
   def test_template_warning


### PR DESCRIPTION
### Describe 
I see warning (eval):1: warning: method redefined; discarding old sitemap_sample

### Steps to reproduce
1. Create rails application
```
rails new test-eval
cd test-eval
```
2. Add gem `sitemap_generator`
```
bundle add sitemap_generator -v=6.3.0
```
3. Run command
```
bundle exec rake -T
```

### Environment
* Ruby version: 3.2.1
* Bundle version: 2.4.5
* Integration framework version:
    * Rack: 3.0.11
    * Rails: 7.1.3.2
    * Rake: 13.2.1
    

<details><summary>Error messages:</summary>

```
(eval):1: warning: method redefined; discarding old sitemap_sample
```
</details>